### PR TITLE
improve code-coverage

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -4,3 +4,4 @@ flow: false
 coverage: true
 check-coverage: false
 files: ['./tests/**/*.ts']
+nyc-arg: [ "--exclude=tests/*" ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import fp from 'fastify-plugin'
 import { flashFactory } from './flash'
 
 export = fp<{}>(
-  function (fastify, opts = {}, done) {
+  function (fastify, opts, done) {
     const flash = flashFactory()
 
     fastify.decorateRequest('flash', flash.request)


### PR DESCRIPTION
Well. it just ignores the test file and removes the unused options-object.

I tried to get the last branch to be covered. But this is i think a false positive and i could have written it like 


```typescript
    reply(type?: string): ReplyReturn {
      if (type) {
        const flash = this.request.session.get('flash')
        const messages = flash[type]
        delete flash[type];
        this.request.session.set('flash', flash)
        return messages || []
      }
      const messages = this.request.session.get('flash')
      this.request.session.set('flash', {})
      return messages
    },
```

But I strongly assume, that deleting the key is a performance bottleneck and not worth to do it just for 100% code coverage