### PR TITLE
Avoid use a runtime hook when a decorator check is sufficient

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -2,6 +2,6 @@ ts: true
 jsx: false
 flow: false
 coverage: true
-check-coverage: false
+check-coverage: true
 files: ['./tests/**/*.ts']
 nyc-arg: [ "--exclude=tests/*" ]

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -9,6 +9,9 @@ type ReplyReturn =
 export function flashFactory() {
   return {
     request(type: string, ...message: string[] | [string[]]): number {
+      if (!this.session) {
+        throw new Error('Session not found')
+      }
       let currentSession = this.session.get('flash')
       if (!currentSession) {
         currentSession = {}
@@ -39,14 +42,24 @@ export function flashFactory() {
     },
 
     reply(type?: string): ReplyReturn {
+      if (!this.request.session) {
+        throw new Error('Session not found')
+      }
       if (!type) {
         const allMessages = this.request.session.get('flash')
         this.request.session.set('flash', {})
         return allMessages
       }
 
-      const { [type]: messages, ...flash } = this.request.session.get('flash') || {}
-      this.request.session.set('flash', flash)
+      let data = this.request.session.get('flash')
+      if (!data)  {
+        data = {} 
+      }
+
+      const messages = data[type]
+      delete data[type]
+
+      this.request.session.set('flash', data)
 
       return messages || []
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,17 +7,13 @@ export = fp<{}>(
 
     fastify.decorateRequest('flash', flash.request)
     fastify.decorateReply('flash', flash.reply)
-
-    fastify.addHook('onRequest', function (request, reply, next) {
-      if (!request.session) {
-        next(Error('Flash plugin requires a valid session.'))
-      }
-      next()
-    })
     done()
   },
   {
     fastify: '4.x',
     name: '@fastify/flash',
-  },
+    decorators: {
+      request: ['session']
+    }
+  }
 )

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -5,7 +5,6 @@ import { readFileSync } from 'fs'
 import Fastify from 'fastify'
 import fastifySession from '@fastify/secure-session'
 import querystring from 'querystring'
-
 import fastifyFlash from '../src'
 
 const key = readFileSync(join(__dirname, '..', 'secret-key'))
@@ -267,21 +266,6 @@ test('should return empty array when the type is not set', async t => {
   })
   t.equal(response.payload, '{"warning":[]}')
   t.equal(response.statusCode, 200)
-})
-
-test('should return error when session is not defined.', async t => {
-  t.plan(2)
-  const fastify = Fastify()
-  fastify.register(fastifyFlash)
-
-  fastify.get('/test', (req, reply) => {})
-
-  const response = await fastify.inject({
-    method: 'GET',
-    url: '/test',
-  })
-  t.equal(response.payload, '{"statusCode":500,"error":"Internal Server Error","message":"Flash plugin requires a valid session."}')
-  t.equal(response.statusCode, 500)
 })
 
 test('should throw error when try to set flash without message.', async t => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -110,7 +110,53 @@ test('should pass flash between requests.', async t => {
     reply.send({})
   })
 
-  fastify.get('/test2', (req, reply) => {
+  fastify.get('/test2', (_, reply) => {
+    const warning = reply.flash('warning')
+    t.equal(warning.length, 2)
+
+    t.equal(warning[0], 'username required')
+    t.equal(warning[1], 'password required')
+    reply.send({ warning })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/test',
+  })
+
+  t.equal(response.payload, '{}')
+  t.equal(response.statusCode, 200)
+
+  const response2 = await (fastify as any).inject({
+    method: 'GET',
+    url: '/test2',
+    cookies: {
+      [(response.headers['set-cookie'] as string).split('=')[0]]: querystring.unescape(
+        (response.headers['set-cookie'] as string).split('=')[1],
+      ),
+    },
+  })
+  t.equal(response2.payload, '{"warning":["username required","password required"]}')
+  t.equal(response2.statusCode, 200)
+})
+
+test('should pass flash between requests. / 2', async t => {
+  t.plan(8)
+  const fastify = Fastify()
+
+  fastify.register(fastifySession, {
+    key,
+  })
+  fastify.register(fastifyFlash)
+
+  fastify.get('/test', (req, reply) => {
+    const count = req.flash('warning', ['username required', 'password required'])
+    req.flash('info', 'Welcome')
+    t.equal(count, 2)
+    reply.send({})
+  })
+
+  fastify.get('/test2', (_, reply) => {
     const warning = reply.flash('warning')
     t.equal(warning.length, 2)
 
@@ -277,7 +323,7 @@ test('should throw error when try to set flash without message.', async t => {
   })
   fastify.register(fastifyFlash, {})
 
-  fastify.get('/test', (req, reply) => {
+  fastify.get('/test', (req) => {
     req.flash('info')
   })
 
@@ -287,4 +333,60 @@ test('should throw error when try to set flash without message.', async t => {
   })
   t.equal(response.payload, '{"statusCode":500,"error":"Internal Server Error","message":"Provide a message to flash."}')
   t.equal(response.statusCode, 500)
+})
+
+test('should return error when session is not defined.', async t => {
+  t.plan(4)
+  const fastify = Fastify()
+  fastify.decorateRequest('session', null)
+  fastify.register(fastifyFlash)
+
+  fastify.get('/test', async (req) => {
+    req.flash('error', 'Something went wrong')
+  })
+
+  fastify.get('/test2', async (_, reply) => {
+    reply.flash('error')
+  })
+
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+    })
+    t.equal(response.payload, '{"statusCode":500,"error":"Internal Server Error","message":"Session not found"}')
+    t.equal(response.statusCode, 500)
+  }
+
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/test2',
+    })
+    t.equal(response.payload, '{"statusCode":500,"error":"Internal Server Error","message":"Session not found"}')
+    t.equal(response.statusCode, 500)
+  }
+})
+
+test('reply.flash() with no data', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(fastifySession, {
+    key,
+  })
+
+  fastify.register(fastifyFlash)
+
+  fastify.get('/test', (_, reply) => {
+    const warning = reply.flash('warning')
+    reply.send({ warning })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/test',
+  })
+  t.equal(response.payload, '{"warning":[]}')
+  t.equal(response.statusCode, 200)
 })


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
