### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/src/flash.ts
+++ b/src/flash.ts
@@ -1,4 +1,4 @@
-import { format } from 'util'
+import { format } from 'node:util'
 
 type ReplyReturn =
   | {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,9 +1,9 @@
 import { test, TestContext } from 'node:test'
-import { join } from 'path'
-import { readFileSync } from 'fs'
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
 import Fastify from 'fastify'
 import fastifySession from '@fastify/secure-session'
-import querystring from 'querystring'
+import querystring from 'node:querystring'
 import fastifyFlash from '../src'
 
 const key = readFileSync(join(__dirname, '..', '..', 'secret-key'))


### PR DESCRIPTION
This is a batch PR, so may have some issues. Please review changes.