### PR TITLE
docs(readme): improve example code with better default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ fastify.register(fastifySession, {
   key: fs.readFileSync(path.join(__dirname, 'secret-key')),
   cookie: {
     // options from setCookie, see https://github.com/fastify/fastify-cookie
+    path: "/"
   }
 })
-fastify.register(fastifyFlash)
+fastify.register(fastifyFlash, {
+  prefix: "/"
+})
 
 fastify.get('/test', (req, reply) => {
   req.flash('warning', ['username required', 'password required'])


### PR DESCRIPTION
## Change Description

Add a cookie configuration to the example docs for registering the `fastify-secure-session` plugin per the [example in the README doc of that repo](https://github.com/fastify/fastify-secure-session/blob/64f8d9b64bc52cadaf62fa658ba66eed195b5486/README.md?plain=1#L59-L62).

Setting a cookie path is important for flash message session cookies, otherwise every request for a different URL path will get its own cookie set i.e. because we don't specify a cookie path, every new path visited sets a session cookie. That may be valid in some use-cases, but that's not going to be the expected behavior for most users looking for a flash message solution.

## Context

After following the example code here, I ran into an unexpected bug with the flash messages only being present from the URL path where they were set, and not being cleared on navigation. The issue was that the flash message was set in a cookie with `path` for the URL I visited when I got the flash message and navigating to a different URL did not clear that flash message because this library was looking to clear a session cookie for the newly visited URL. This meant re-visiting the original URL resulted in the flash message always being present.

We should try to steer users away from making the same mistake I did.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
