### PR TITLE
chore: upgrade @type/node v26.x and removed unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,13 +57,11 @@
   "devDependencies": {
     "@fastify/secure-session": "^8.0.0",
     "@types/node": "^26.0.0",
-    "fastify": "^5.0.0",
-    "prettier": "^3.2.5",
-    "rimraf": "^6.0.1",
     "borp": "^0.21.0",
-    "ts-node": "^10.9.2",
     "eslint": "^9.35.0",
+    "fastify": "^5.0.0",
     "neostandard": "^0.13.0",
+    "rimraf": "^6.0.1",
     "typescript": "~6.0.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "devDependencies": {
     "@fastify/secure-session": "^8.0.0",
-    "@types/node": "^25.0.3",
+    "@types/node": "^26.0.0",
     "fastify": "^5.0.0",
     "prettier": "^3.2.5",
     "rimraf": "^6.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "strictPropertyInitialization": true,
     "esModuleInterop": true,
     "removeComments": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "skipLibCheck": true
   },
   "exclude": ["node_modules"],
   "include": ["./src/**/*.ts", "./tests/**/*.ts"],


### PR DESCRIPTION
Proposal:

- upgrade `@type/node` dependency from `v25.x` to `v26.x`
- removed unused dependencies ( `prettier`, `ts-node`)
- added `skipLibCheck` in `tsconfig.json`, necessary for updating `@type/node` ( see screenshot )


<img width="1742" height="1081" alt="screenshot-error" src="https://github.com/user-attachments/assets/20595de8-48d4-45aa-a0a1-9075d38b2fe6" />
